### PR TITLE
Fixes issue #43

### DIFF
--- a/postcards/plugin_folder/postcards_folder.py
+++ b/postcards/plugin_folder/postcards_folder.py
@@ -91,13 +91,13 @@ class PostcardsFolder(Postcards):
         if os.path.exists(high_prio):
             for file in os.listdir(high_prio):
                 for ext in self.supported_ext:
-                    if file.endswith(ext):
+                    if file.lower().endswith(ext):
                         candidates.append(os.path.join(self.high_prio_folder, file))
 
         if not candidates:
             for file in os.listdir(folder):
                 for ext in self.supported_ext:
-                    if file.endswith(ext):
+                    if file.lower().endswith(ext):
                         candidates.append(file)
 
         if not candidates:


### PR DESCRIPTION
Added a ```.lower()``` to the file extension checking part in the python file ```postcards/plugin_folder/postcards_folder.py``` so that, for example, both ```.jpg``` and ```.JPG``` files get recognized and accepted as images.